### PR TITLE
Change version to 1.0.0, change api to _opensearch

### DIFF
--- a/.github/workflows/dashboards-notebooks-release-workflow.yml
+++ b/.github/workflows/dashboards-notebooks-release-workflow.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PLUGIN_NAME: notebooksDashboards
-  OD_VERSION: 1.15.0.0
+  OD_VERSION: 1.0.0.0
 
 jobs:
 
@@ -28,12 +28,11 @@ jobs:
       - name: Checkout Plugin
         uses: actions/checkout@v1
 
-      # TODO change to opensearch
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v1
         with:
           repository: opensearch-project/Opensearch-Dashboards
-          ref: 1.x
+          ref: main
           path: dashboards-notebooks/OpenSearch-Dashboards
 
       - name: Setup Node

--- a/.github/workflows/dashboards-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notebooks-test-and-build-workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 
 env:
   PLUGIN_NAME: notebooksDashboards
-  OD_VERSION: 1.15.0.0
+  OD_VERSION: 1.0.0.0
 
 jobs:
 
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           repository: opensearch-project/Opensearch-Dashboards
-          ref: 1.x
+          ref: main
           path: dashboards-notebooks/OpenSearch-Dashboards
 
       - name: Setup Node

--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -20,9 +20,10 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
+          ref: '1.0.0-alpha1'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils
@@ -33,11 +34,12 @@ jobs:
       - name: Build common-utils
         working-directory: ./common-utils
         run: ./gradlew publishToMavenLocal
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha1
 
       - name: Build with Gradle
         run: |
           cd opensearch-notebooks
-          ./gradlew build
+          ./gradlew build -Dopensearch.version=1.0.0-alpha1
 
       - name: Create Artifact Path
         run: |

--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -14,6 +14,26 @@ jobs:
         with:
           java-version: 1.14
 
+      # dependencies: OpenSearch
+      - name: Checkout OpenSearch
+        uses: actions/checkout@v2
+        with:
+          repository: 'opensearch-project/OpenSearch'
+          path: OpenSearch
+      - name: Build OpenSearch
+        working-directory: ./OpenSearch
+        run: ./gradlew publishToMavenLocal
+
+      # dependencies: common-utils
+      - name: Checkout common-utils
+        uses: actions/checkout@v2
+        with:
+          repository: 'opensearch-project/common-utils'
+          path: common-utils
+      - name: Build common-utils
+        working-directory: ./common-utils
+        run: ./gradlew publishToMavenLocal
+
       - name: Build with Gradle
         run: |
           cd opensearch-notebooks

--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -33,7 +33,6 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal
         run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha1
 
       - name: Build with Gradle

--- a/dashboards-notebooks/.cypress/utils/constants.js
+++ b/dashboards-notebooks/.cypress/utils/constants.js
@@ -16,7 +16,7 @@
 
 export const delay = 1000;
 export const TEST_NOTEBOOK = 'Test Notebook';
-export const SAMPLE_URL = 'https://github.com/opendistro-for-elasticsearch/sql/tree/master/sql-jdbc';
+export const SAMPLE_URL = 'https://github.com/opensearch-project/sql/tree/main/sql-jdbc';
 export const MARKDOWN_TEXT = `%md
 # Heading 1
 
@@ -30,7 +30,7 @@ export const MARKDOWN_TEXT = `%md
 #### Code block
 * Explain SQL
 \`\`\`
-POST _opendistro/_sql/_explain
+POST _opensearch/_sql/_explain
 {
   "query": "SELECT * FROM my-index LIMIT 50"
 }

--- a/dashboards-notebooks/common/index.ts
+++ b/dashboards-notebooks/common/index.ts
@@ -31,7 +31,7 @@ export const wreckOptions = {
   headers: { 'Content-Type': 'application/json' },
 };
 
-const BASE_NOTEBOOKS_URI = '/_opendistro/_notebooks';
+const BASE_NOTEBOOKS_URI = '/_opensearch/_notebooks';
 export const OPENSEARCH_NOTEBOOKS_API = {
   GET_NOTEBOOKS: `${BASE_NOTEBOOKS_URI}/notebooks`,
   NOTEBOOK: `${BASE_NOTEBOOKS_URI}/notebook`,

--- a/dashboards-notebooks/opensearch_dashboards.json
+++ b/dashboards-notebooks/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "notebooksDashboards",
-  "version": "1.0.0",
+  "version": "1.0.0.0",
   "opensearchDashboardsVersion": "1.0.0",
   "server": true,
   "ui": true,

--- a/dashboards-notebooks/opensearch_dashboards.json
+++ b/dashboards-notebooks/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "notebooksDashboards",
-  "version": "1.15.0.0",
-  "opensearchDashboardsVersion": "7.10.2",
+  "version": "1.0.0",
+  "opensearchDashboardsVersion": "1.0.0",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation", "embeddable", "dashboard"],

--- a/dashboards-notebooks/package.json
+++ b/dashboards-notebooks/package.json
@@ -1,11 +1,11 @@
 {
   "name": "notebooks-dashboards",
-  "version": "1.15.0.0",
+  "version": "1.0.0",
   "description": "OpenSearch Dashboards Notebooks",
   "main": "index.ts",
   "license": "Apache-2.0",
   "opensearchDashboards": {
-    "version": "7.10.2",
+    "version": "1.0.0",
     "templateVersion": "1.0.0"
   },
   "scripts": {

--- a/dashboards-notebooks/package.json
+++ b/dashboards-notebooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notebooks-dashboards",
-  "version": "1.0.0",
+  "version": "1.0.0.0",
   "description": "OpenSearch Dashboards Notebooks",
   "main": "index.ts",
   "license": "Apache-2.0",

--- a/dashboards-notebooks/server/services/utils/constants.ts
+++ b/dashboards-notebooks/server/services/utils/constants.ts
@@ -13,10 +13,10 @@
  *   permissions and limitations under the License.
  */
 
-export const SQL_TRANSLATE_ROUTE = `/_opendistro/_sql/_explain`;
-export const PPL_TRANSLATE_ROUTE = `/_opendistro/_ppl/_explain`;
-export const SQL_QUERY_ROUTE = `/_opendistro/_sql`;
-export const PPL_QUERY_ROUTE = `/_opendistro/_ppl`;
+export const SQL_TRANSLATE_ROUTE = `/_opensearch/_sql/_explain`;
+export const PPL_TRANSLATE_ROUTE = `/_opensearch/_ppl/_explain`;
+export const SQL_QUERY_ROUTE = `/_opensearch/_sql`;
+export const PPL_QUERY_ROUTE = `/_opensearch/_ppl`;
 export const FORMAT_CSV = `format=csv`;
 export const FORMAT_JSON = `format=json`;
 export const FORMAT_TEXT = `format=raw`;

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.opensearch.gradle:build-tools:${opensearch_version}-SNAPSHOT"
+        classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
         classpath "org.jetbrains.kotlin:kotlin-allopen:${kotlin_version}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.12.0"
@@ -127,7 +127,7 @@ allprojects {
 }
 
 dependencies {
-    compile "org.opensearch:opensearch:${opensearch_version}-SNAPSHOT"
+    compile "org.opensearch:opensearch:${opensearch_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
@@ -138,7 +138,7 @@ dependencies {
             'org.junit.jupiter:junit-jupiter-api:5.6.2'
     )
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.6.2')
-    testCompile "org.opensearch.test:framework:${opensearch_version}-SNAPSHOT"
+    testCompile "org.opensearch.test:framework:${opensearch_version}"
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testCompile "org.mockito:mockito-core:2.23.0"

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -18,20 +18,14 @@ import java.util.concurrent.Callable
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "7.10.3")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
         kotlin_version = System.getProperty("kotlin.version", "1.4.0")
     }
 
     repositories {
+        mavenLocal()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven {
-            url = 's3://search-vemsarat/'
-            credentials(AwsCredentials) {
-              accessKey = System.env.AWS_ACCESS_KEY_ID ?: findProperty('aws_access_key_id')
-              secretKey = System.env.AWS_SECRET_ACCESS_KEY ?: findProperty('aws_secret_access_key')
-            }
-        }
         jcenter()
     }
 
@@ -97,15 +91,9 @@ configurations.all {
 }
 
 repositories {
+  mavenLocal()
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
-    maven {
-        url = 's3://search-vemsarat/'
-        credentials(AwsCredentials) {
-            accessKey = System.env.AWS_ACCESS_KEY_ID ?: findProperty('aws_access_key_id')
-            secretKey = System.env.AWS_SECRET_ACCESS_KEY ?: findProperty('aws_secret_access_key')
-        }
-    }
     jcenter()
 }
 

--- a/opensearch-notebooks/gradle.properties
+++ b/opensearch-notebooks/gradle.properties
@@ -13,4 +13,4 @@
 #   permissions and limitations under the License.
 #
 
-version = 1.15.0
+version = 1.0.0

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/NotebooksPlugin.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/NotebooksPlugin.kt
@@ -58,7 +58,7 @@ class NotebooksPlugin : Plugin(), ActionPlugin {
     companion object {
         const val PLUGIN_NAME = "opensearch-notebooks"
         const val LOG_PREFIX = "notebooks"
-        const val BASE_NOTEBOOKS_URI = "/_opendistro/_notebooks"
+        const val BASE_NOTEBOOKS_URI = "/_opensearch/_notebooks"
     }
 
     /**


### PR DESCRIPTION
### Description
- changed plugin versions to 1.0.0
- changed notebooks api to use _opensearch (plugin didn't release yet, no need to maintain backward compatibility)
- changed SQL api to use _opensearch
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
