### PR TITLE
Rename opendistro to opensearch

### DIFF
--- a/.github/workflows/opensearch-notebooks-release-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-release-workflow.yml
@@ -1,5 +1,5 @@
 name: Release OpenSearch Notebooks Backend Plugin Artifacts
-# This workflow is triggered on creating tags to master or an opendistro release branch
+# This workflow is triggered on creating tags to main or an opensearch release branch
 on:
   push:
     tags:

--- a/dashboards-notebooks/README.md
+++ b/dashboards-notebooks/README.md
@@ -36,7 +36,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/opendistroNotebooks*.zip`
+Example output: `./build/notebooksDashboards*.zip`
 
 
 ## Run

--- a/dashboards-notebooks/public/components/__test__/sampleDefaultNotebooks.tsx
+++ b/dashboards-notebooks/public/components/__test__/sampleDefaultNotebooks.tsx
@@ -134,14 +134,14 @@ export const sampleNotebook2 = {
       output: [
         {
           result:
-            '# Type no output here\n* Sample link: [link](https://opendistro.github.io/for-elasticsearch/)\n* ~~Strike~~, **Bold**, __Italic__',
+            '# Type no output here\n* Sample link: [link](https://github.com/opensearch-project)\n* ~~Strike~~, **Bold**, __Italic__',
           outputType: 'MARKDOWN',
           execution_time: '0s',
         },
       ],
       input: {
         inputText:
-          '# Type no output here\n* Sample link: [link](https://opendistro.github.io/for-elasticsearch/)\n* ~~Strike~~, **Bold**, __Italic__',
+          '# Type no output here\n* Sample link: [link](https://github.com/opensearch-project)\n* ~~Strike~~, **Bold**, __Italic__',
         inputType: 'MARKDOWN',
       },
       dateCreated: '2020-08-20T18:00:59.845Z',
@@ -184,12 +184,12 @@ export const sampleParsedParagraghs2 = [
     vizObjectInput: '',
     id: 1,
     inp:
-      '# Type no output here\n* Sample link: [link](https://opendistro.github.io/for-elasticsearch/)\n* ~~Strike~~, **Bold**, __Italic__',
+      '# Type no output here\n* Sample link: [link](https://github.com/opensearch-project)\n* ~~Strike~~, **Bold**, __Italic__',
     lang: 'text/x-md',
     editorLanguage: 'md',
     typeOut: ['MARKDOWN'],
     out: [
-      '# Type no output here\n* Sample link: [link](https://opendistro.github.io/for-elasticsearch/)\n* ~~Strike~~, **Bold**, __Italic__',
+      '# Type no output here\n* Sample link: [link](https://github.com/opensearch-project)\n* ~~Strike~~, **Bold**, __Italic__',
     ],
   },
   {
@@ -245,7 +245,7 @@ export const sampleNotebook3 = {
       output: [
         {
           result:
-            '# Type no output here\n* Sample link: [link](https://opendistro.github.io/for-elasticsearch/)\n* ~~Strike~~, **Bold**, __Italic__',
+            '# Type no output here\n* Sample link: [link](https://github.com/opensearch-project)\n* ~~Strike~~, **Bold**, __Italic__',
           outputType: 'MARKDOWN',
           execution_time: '0s',
         },
@@ -270,7 +270,7 @@ export const sampleNotebook4 = {
       output: [
         {
           result:
-            '# Type no output here\n* Sample link: [link](https://opendistro.github.io/for-elasticsearch/)\n* ~~Strike~~, **Bold**, __Italic__',
+            '# Type no output here\n* Sample link: [link](https://github.com/opensearch-project)\n* ~~Strike~~, **Bold**, __Italic__',
           outputType: 'MARKDOWN',
           execution_time: '0s',
         },

--- a/dashboards-notebooks/server/services/utils/constants.ts
+++ b/dashboards-notebooks/server/services/utils/constants.ts
@@ -39,6 +39,6 @@ export const DEFAULT_HEADERS = {
 
 export const CLUSTER = {
   ADMIN: 'admin',
-  SQL: 'opendistro_sql',
+  SQL: 'opensearch-sql',
   DATA: 'data',
 };

--- a/opensearch-notebooks/build-tools/pkgbuild.gradle
+++ b/opensearch-notebooks/build-tools/pkgbuild.gradle
@@ -54,7 +54,7 @@ afterEvaluate {
         maintainer 'OpenSearch Team <opensearch@amazon.com>'
         url 'https://opensearch.org/'
         summary '''
-         OpenSearch Reports scheduler.
+         OpenSearch Notebooks.
          Reference documentation can be found at https://opendistro.github.io/elasticsearch/docs.
     '''.stripIndent().replace('\n', ' ').trim()
     }

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -112,7 +112,7 @@ ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
-    opendistroVersion = "${version}"
+    opensearchVersion = "${version}"
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -130,7 +130,7 @@ plugins.withId('org.jetbrains.kotlin.jvm') {
 
 allprojects {
     group = "com.amazon.opendistroforelasticsearch"
-    version = "${opendistroVersion}.0"
+    version = "${opensearchVersion}.0"
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
@@ -142,7 +142,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
-    compile "${group}:common-utils:${opendistroVersion}.0"
+    compile "${group}:common-utils:${opensearchVersion}.0"
     compile group: 'com.google.guava', name: 'guava', version: '15.0'
     testImplementation(
             'org.assertj:assertj-core:3.16.1',

--- a/opensearch-notebooks/src/main/config/notebooks.yml
+++ b/opensearch-notebooks/src/main/config/notebooks.yml
@@ -27,7 +27,7 @@
 ##
 
 # configuration file for the notebooks plugin
-opendistro.notebooks:
+opensearch.notebooks:
   general:
     operationTimeoutMs: 60000 # 60 seconds, Minimum 100ms
     defaultItemsQueryCount: 100 # default number of items to query

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/NotebooksPlugin.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/NotebooksPlugin.kt
@@ -61,7 +61,7 @@ import org.opensearch.watcher.ResourceWatcherService
 import java.util.function.Supplier
 
 /**
- * Entry point of the OpenDistro for Elasticsearch Notebooks plugin.
+ * Entry point of the OpenSearch Notebooks plugin.
  * This class initializes the rest handlers.
  */
 class NotebooksPlugin : Plugin(), ActionPlugin {

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/CreateNotebookAction.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/CreateNotebookAction.kt
@@ -51,7 +51,7 @@ internal class CreateNotebookAction @Inject constructor(
     actionFilters,
     ::CreateNotebookRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/notebooks/create"
+        private const val NAME = "cluster:admin/opensearch/notebooks/create"
         internal val ACTION_TYPE = ActionType(NAME, ::CreateNotebookResponse)
     }
 

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/DeleteNotebookAction.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/DeleteNotebookAction.kt
@@ -51,7 +51,7 @@ internal class DeleteNotebookAction @Inject constructor(
     actionFilters,
     ::DeleteNotebookRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/notebooks/delete"
+        private const val NAME = "cluster:admin/opensearch/notebooks/delete"
         internal val ACTION_TYPE = ActionType(NAME, ::DeleteNotebookResponse)
     }
 

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/GetAllNotebooksAction.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/GetAllNotebooksAction.kt
@@ -51,7 +51,7 @@ internal class GetAllNotebooksAction @Inject constructor(
     actionFilters,
     ::GetAllNotebooksRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/notebooks/list"
+        private const val NAME = "cluster:admin/opensearch/notebooks/list"
         internal val ACTION_TYPE = ActionType(NAME, ::GetAllNotebooksResponse)
     }
 

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/GetNotebookAction.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/GetNotebookAction.kt
@@ -51,7 +51,7 @@ internal class GetNotebookAction @Inject constructor(
     actionFilters,
     ::GetNotebookRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/notebooks/get"
+        private const val NAME = "cluster:admin/opensearch/notebooks/get"
         internal val ACTION_TYPE = ActionType(NAME, ::GetNotebookResponse)
     }
 

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/UpdateNotebookAction.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/UpdateNotebookAction.kt
@@ -51,7 +51,7 @@ internal class UpdateNotebookAction @Inject constructor(
     actionFilters,
     ::UpdateNotebookRequest) {
     companion object {
-        private const val NAME = "cluster:admin/opendistro/notebooks/update"
+        private const val NAME = "cluster:admin/opensearch/notebooks/update"
         internal val ACTION_TYPE = ActionType(NAME, ::UpdateNotebookResponse)
     }
 

--- a/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/settings/PluginSettings.kt
+++ b/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/settings/PluginSettings.kt
@@ -47,7 +47,7 @@ internal object PluginSettings {
     /**
      * Settings Key prefix for this plugin.
      */
-    private const val KEY_PREFIX = "opendistro.notebooks"
+    private const val KEY_PREFIX = "opensearch.notebooks"
 
     /**
      * General settings Key prefix.

--- a/opensearch-notebooks/src/test/kotlin/com/amazon/opendistroforelasticsearch/notebooks/PluginRestTestCase.kt
+++ b/opensearch-notebooks/src/test/kotlin/com/amazon/opendistroforelasticsearch/notebooks/PluginRestTestCase.kt
@@ -97,8 +97,8 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
             for (index in parser.list()) {
                 val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
                 val indexName: String = jsonObject["index"] as String
-                // .opensearch_security isn't allowed to delete from cluster
-                if (indexName != ".opensearch_security") {
+                // .opendistro_security isn't allowed to delete from cluster
+                if (indexName != ".opendistro_security") {
                     client().performRequest(Request("DELETE", "/$indexName"))
                 }
             }

--- a/opensearch-notebooks/src/test/kotlin/com/amazon/opendistroforelasticsearch/notebooks/PluginRestTestCase.kt
+++ b/opensearch-notebooks/src/test/kotlin/com/amazon/opendistroforelasticsearch/notebooks/PluginRestTestCase.kt
@@ -97,8 +97,8 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
             for (index in parser.list()) {
                 val jsonObject: Map<*, *> = index as java.util.HashMap<*, *>
                 val indexName: String = jsonObject["index"] as String
-                // .opendistro_security isn't allowed to delete from cluster
-                if (indexName != ".opendistro_security") {
+                // .opensearch_security isn't allowed to delete from cluster
+                if (indexName != ".opensearch_security") {
                     client().performRequest(Request("DELETE", "/$indexName"))
                 }
             }


### PR DESCRIPTION
### Description
Change opendistro to opensearch for notebooks API

**TODO**: need to confirm if these need to change
https://github.com/opensearch-project/dashboards-notebooks/blob/2bc9521a37fc48d5e5cadea87338a0cad32f0974/opensearch-notebooks/src/main/kotlin/com/amazon/opendistroforelasticsearch/notebooks/action/PluginBaseAction.kt#L30
https://github.com/opensearch-project/dashboards-notebooks/blob/2bc9521a37fc48d5e5cadea87338a0cad32f0974/opensearch-notebooks/src/test/kotlin/com/amazon/opendistroforelasticsearch/notebooks/PluginRestTestCase.kt#L101
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
