### PR TITLE
Migrate to OpenSearch Alpha2

### DIFF
--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
+          ref: '1.0.0-alpha2'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils

--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0.0-alpha1'
+          ref: '1.0.0-alpha2'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha1 -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal -Dbuild.version_qualifier=alpha2 -Dbuild.snapshot=false
 
       # dependencies: common-utils
       - name: Checkout common-utils
@@ -33,12 +33,12 @@ jobs:
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha1
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0-alpha2
 
       - name: Build with Gradle
         run: |
           cd opensearch-notebooks
-          ./gradlew build -Dopensearch.version=1.0.0-alpha1
+          ./gradlew build -Dopensearch.version=1.0.0-alpha2
 
       - name: Create Artifact Path
         run: |

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -242,7 +242,7 @@ integTest.dependsOn(bundle)
 integTest.getClusters().forEach{c -> c.plugin(project.getObjects().fileProperty().value(bundle.getArchiveFile()))}
 
 testClusters.integTest {
-    testDistribution = 'OSS'
+    testDistribution = 'ARCHIVE'
     // Cluster shrink exception thrown if we try to set numberOfNodes to 1, so only apply if > 1
     if (_numNodes > 1) numberOfNodes = _numNodes
     // When running integration tests it doesn't forward the --debug-jvm to the cluster anymore

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -112,7 +112,7 @@ ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
-    opendistroVersion = "${version}"
+    opensearchVersion = "${version}"
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -130,7 +130,7 @@ plugins.withId('org.jetbrains.kotlin.jvm') {
 
 allprojects {
     group = "com.amazon.opendistroforelasticsearch"
-    version = "${opendistroVersion}.0"
+    version = "${opensearchVersion}.0-alpha2"
 
     plugins.withId('java') {
         sourceCompatibility = targetCompatibility = "1.8"
@@ -142,7 +142,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
-    compile "${group}:common-utils:${opendistroVersion}.0"
+    compile "${group}:common-utils:${opensearchVersion}.0"
     compile group: 'com.google.guava', name: 'guava', version: '15.0'
     testImplementation(
             'org.assertj:assertj-core:3.16.1',

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.0.0")
+        opensearch_version = System.getProperty("opensearch.version", "1.0.0-alpha2")
         kotlin_version = System.getProperty("kotlin.version", "1.4.0")
     }
 

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
-    compile "${group}:common-utils:${opensearchVersion}.0"
+    compile "${group}:common-utils:${version}"
     compile group: 'com.google.guava', name: 'guava', version: '15.0'
     testImplementation(
             'org.assertj:assertj-core:3.16.1',


### PR DESCRIPTION
### Description
Migrate to OpenSearch 1.0.0.0-alpha2 and pass CI
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
