### PR TITLE
Add Context Menu for Reporting Integration

### DIFF
--- a/dashboards-notebooks/public/components/helpers/custom_modals/reporting_loading_modal.tsx
+++ b/dashboards-notebooks/public/components/helpers/custom_modals/reporting_loading_modal.tsx
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { 
+  EuiOverlayMask, 
+  EuiModal, 
+  EuiModalHeader, 
+  EuiTitle, 
+  EuiText, 
+  EuiModalBody, 
+  EuiSpacer, 
+  EuiFlexGroup, 
+  EuiFlexItem, 
+  EuiLoadingSpinner, 
+  EuiButton 
+} from "@elastic/eui";
+import React, { useState } from "react";
+
+export function GenerateReportLoadingModal(props: { setShowLoading: any; }) {
+  const {
+    setShowLoading
+  } = props;
+  
+  const [isModalVisible, setIsModalVisible] = useState(true);
+
+  const closeModal = () => {
+    setIsModalVisible(false);
+    setShowLoading(false);
+  };
+  const showModal = () => setIsModalVisible(true);
+
+  return (
+    <div>
+      <EuiOverlayMask>
+        <EuiModal
+          onClose={closeModal}
+          style={{ maxWidth: 350, minWidth: 300 }}
+          id="downloadInProgressLoadingModal"
+        >
+          <EuiModalHeader>
+            <EuiTitle>
+              <EuiText textAlign="right">
+                <h2>Generating report</h2>
+              </EuiText>
+            </EuiTitle>
+          </EuiModalHeader>
+          <EuiModalBody>
+            <EuiText>Preparing your file for download.</EuiText>
+            <EuiText>
+              You can close this dialog while we continue in the background.
+            </EuiText>
+            <EuiSpacer />
+            <EuiFlexGroup justifyContent="center" alignItems="center">
+              <EuiFlexItem grow={false}>
+                <EuiLoadingSpinner
+                  size="xl"
+                  style={{ minWidth: 75, minHeight: 75 }}
+                />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="l" />
+            <EuiFlexGroup alignItems="flexEnd" justifyContent="flexEnd">
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={closeModal}>Close</EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiModalBody>
+        </EuiModal>
+      </EuiOverlayMask>
+    </div>
+  );
+};

--- a/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
+++ b/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
@@ -33,8 +33,10 @@ const getReportSourceURL = (baseURI: string) => {
 export const generateInContextReport = (
   fileFormat: string,
   props: any,
+  toggleReportingLoadingModal: any,
   rest = {}
 ) => {
+  toggleReportingLoadingModal(true);
   const baseUrl = location.pathname + location.hash;
   const reportSource = 'Notebook';
   const contextMenuOnDemandReport = {
@@ -86,6 +88,7 @@ export const generateInContextReport = (
     }
   )
   .then((response) => {
+    toggleReportingLoadingModal(false);
     if (response.status === 200) {
       // success toast
       props.setToast('Successfully generated report.', 'success');

--- a/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
+++ b/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
@@ -70,7 +70,7 @@ export const generateInContextReport = (
     {
       headers: {
         'Content-Type': 'application/json',
-        'osd-version': '7.10.2',
+        'osd-version': '1.0.0',
         accept: '*/*',
         'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
         pragma: 'no-cache',

--- a/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
+++ b/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const getReportSourceURL = (baseURI: string) => {
+  const url = baseURI.substr(baseURI.lastIndexOf('/') + 1, baseURI.length);
+  console.log('url is', url);
+  return url;
+}
+
+export const generateInContextReport = (
+  fileFormat: string,
+  props: any,
+  rest = {}
+) => {
+  const baseUrl = location.pathname + location.hash;
+  const reportSource = 'Notebook';
+  const contextMenuOnDemandReport = {
+    query_url: baseUrl,
+    time_from: 0, // no time range for notebook reports
+    time_to: 0,
+    report_definition: {
+      report_params: {
+        report_name: 'In-context ' + document.getElementById('notebookTitle')?.innerText,
+        report_source: reportSource,
+        description: 'In-context report download',
+        core_params: {
+          base_url: baseUrl,
+          report_format: fileFormat,
+          time_duration: 'PT30M', // time duration can be hard-coded 
+          ...rest,
+        },
+      },
+      delivery: {
+        delivery_type: 'OpenSearch Dashboards user',
+        delivery_params: {
+          opensearch_dashboards_recipients: [],
+        },
+      },
+      trigger: {
+        trigger_type: 'On demand',
+      },
+    },
+  };
+
+  fetch(
+    '../api/reporting/generateReport',
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'osd-version': '7.10.2',
+        accept: '*/*',
+        'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
+        pragma: 'no-cache',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+      },
+      method: 'POST',
+      body: JSON.stringify(contextMenuOnDemandReport),
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      mode: 'cors',
+      credentials: 'include',
+    }
+  )
+  .then((response) => {
+    if (response.status === 200) {
+      // success toast
+      props.setToast('Successfully generated report.', 'success');
+    } else {
+      if (response.status === 403) {
+        // permissions failure toast
+        props.setToast(
+          'Error generating report,',
+          'danger',
+          'Insufficient permissions. Reach out to your OpenSearch Dashboards administrator.'
+        );
+      } else if (response.status === 503) {
+        // timeout failure
+        props.setToast(
+          'Error generating report.',
+          'danger',
+          'Timed out generating on-demand report from notebook. Try again later.'
+        );
+      } else {
+        // generic failure
+        props.setToast(
+          'Download error',
+          'danger',
+          'There was an error generating this report.'
+        );
+      }
+    }
+  });
+}
+
+export const contextMenuCreateReportDefinition = (baseURI: string) => {
+  const reportSourceId = getReportSourceURL(baseURI);
+  let reportSource = 'notebook:';
+
+  reportSource += reportSourceId.toString();
+  window.location.assign(
+    `reports-dashboards#/create?previous=${reportSource}?timeFrom=0?timeTo=0`
+  );
+};
+
+export const contextMenuViewReports = () =>
+  window.location.assign('reports-dashboards#/');

--- a/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
+++ b/dashboards-notebooks/public/components/helpers/reporting_context_menu_helper.tsx
@@ -25,9 +25,7 @@
  */
 
 const getReportSourceURL = (baseURI: string) => {
-  const url = baseURI.substr(baseURI.lastIndexOf('/') + 1, baseURI.length);
-  console.log('url is', url);
-  return url;
+  return baseURI.substr(baseURI.lastIndexOf('/') + 1, baseURI.length);
 }
 
 export const generateInContextReport = (

--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -66,8 +66,7 @@ import {
   contextMenuViewReports,
   contextMenuCreateReportDefinition
 } from './helpers/reporting_context_menu_helper';
-import { EuiGlobalToastList } from '@elastic/eui/src/components/toast/global_toast_list';
-
+import { GenerateReportLoadingModal } from './helpers/custom_modals/reporting_loading_modal';
 const panelStyles: CSS.Properties = {
   float: 'left',
   width: '100%',
@@ -116,6 +115,7 @@ type NotebookState = {
   isNoteActionsPopoverOpen: boolean;
   isReportingPluginInstalled: boolean;
   isReportingActionsPopoverOpen: boolean;
+  isReportingLoadingModalOpen: boolean;
   isModalVisible: boolean;
   modalLayout: React.ReactNode;
   showQueryParagraphError: boolean;
@@ -137,11 +137,16 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       isNoteActionsPopoverOpen: false,
       isReportingPluginInstalled: false,
       isReportingActionsPopoverOpen: false,
+      isReportingLoadingModalOpen: false,
       isModalVisible: false,
       modalLayout: <EuiOverlayMask></EuiOverlayMask>,
       showQueryParagraphError: false,
       queryParagraphErrorMessage: '',
     };
+  }
+
+  toggleReportingLoadingModal = (show: boolean) => {
+    this.setState({isReportingLoadingModalOpen: show});
   }
 
   parseAllParagraphs = () => {
@@ -801,7 +806,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             icon: <EuiIcon type="download" />,
             onClick: () => {
               this.setState({ isReportingActionsPopoverOpen: false });
-              generateInContextReport('pdf', this.props);
+              generateInContextReport('pdf', this.props, this.toggleReportingLoadingModal);
             },
           },
           {
@@ -809,7 +814,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
             icon: <EuiIcon type="download" />,
             onClick: () => {
               this.setState({ isReportingActionsPopoverOpen: false });
-              generateInContextReport('png', this.props);
+              generateInContextReport('png', this.props, this.toggleReportingLoadingModal);
             }
           },
           {
@@ -853,6 +858,9 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         </EuiPopover>
       </div>
     ) : null;
+
+    const showLoadingModal = (this.state.isReportingLoadingModalOpen) ?
+    <GenerateReportLoadingModal setShowLoading={this.toggleReportingLoadingModal} /> : null;
 
     return (
       <div style={pageStyles}>
@@ -1018,6 +1026,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                   </EuiPanel>
                 </div>
               )}
+            {showLoadingModal}
           </EuiPageBody>
         </EuiPage>
         {this.state.isModalVisible && this.state.modalLayout}

--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -61,6 +61,12 @@ import moment from 'moment';
 import { PanelWrapper } from './helpers/panel_wrapper';
 import { getDeleteModal, getCustomModal, DeleteNotebookModal } from './helpers/modal_containers';
 import CSS from 'csstype';
+import { 
+  generateInContextReport,
+  contextMenuViewReports,
+  contextMenuCreateReportDefinition
+} from './helpers/reporting_context_menu_helper';
+import { EuiGlobalToastList } from '@elastic/eui/src/components/toast/global_toast_list';
 
 const panelStyles: CSS.Properties = {
   float: 'left',
@@ -108,6 +114,8 @@ type NotebookState = {
   isAddParaPopoverOpen: boolean;
   isParaActionsPopoverOpen: boolean;
   isNoteActionsPopoverOpen: boolean;
+  isReportingPluginInstalled: boolean;
+  isReportingActionsPopoverOpen: boolean;
   isModalVisible: boolean;
   modalLayout: React.ReactNode;
   showQueryParagraphError: boolean;
@@ -127,6 +135,8 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       isAddParaPopoverOpen: false,
       isParaActionsPopoverOpen: false,
       isNoteActionsPopoverOpen: false,
+      isReportingPluginInstalled: false,
+      isReportingActionsPopoverOpen: false,
       isModalVisible: false,
       modalLayout: <EuiOverlayMask></EuiOverlayMask>,
       showQueryParagraphError: false,
@@ -586,9 +596,42 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     ]);
   }
 
+  checkIfReportingPluginIsInstalled() {
+    fetch('../api/status', 
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'osd-version': '7.10.2',
+        'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
+        pragma: 'no-cache',
+        'sec-fetch-dest': 'empty',
+        'sec-fetch-mode': 'cors',
+        'sec-fetch-site': 'same-origin',
+      },
+      method: 'GET',
+      referrerPolicy: 'strict-origin-when-cross-origin',
+      mode: 'cors',
+      credentials: 'include',
+    })
+    .then(function(response) {
+      return response.json();
+    })
+    .then((data) => {
+      for (let i = 0; i < data.status.statuses.length; ++i) {
+        if (data.status.statuses[i].id.includes('plugin:reportsDashboards')) {
+          this.setState({ isReportingPluginInstalled: true })
+        }
+      }
+    })
+    .catch((error) => {
+      console.log('error is', error);
+    })
+  }
+
   componentDidMount() {
     this.setBreadcrumbs('');
     this.loadNotebook();
+    this.checkIfReportingPluginIsInstalled();
   }
 
   render() {
@@ -748,12 +791,75 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
       },
     ];
 
+    const reportingActionPanels: EuiContextMenuPanelDescriptor[] = [
+      {
+        id: 0,
+        title: 'Reporting',
+        items: [
+          {
+            name: 'Download PDF',
+            icon: <EuiIcon type="download" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              generateInContextReport('pdf', this.props);
+            },
+          },
+          {
+            name: 'Download PNG',
+            icon: <EuiIcon type="download" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              generateInContextReport('png', this.props);
+            }
+          },
+          {
+            name: 'Create report definition',
+            icon: <EuiIcon type="calendar" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              contextMenuCreateReportDefinition(window.location.href)
+            }
+          },
+          {
+            name: 'View reports',
+            icon: <EuiIcon type="document" />,
+            onClick: () => {
+              this.setState({ isReportingActionsPopoverOpen: false });
+              contextMenuViewReports();
+            }
+          }
+        ]
+      }
+    ];
+
+    const showReportingContextMenu = (this.state.isReportingPluginInstalled) ? (
+      <div>
+        <EuiPopover
+          panelPaddingSize="none"
+          withTitle
+          button={
+            <EuiButton
+              iconType='arrowDown'
+              iconSide='right'
+              onClick={() => this.setState({ isReportingActionsPopoverOpen: true })}
+            >
+              Reporting
+            </EuiButton>
+          }
+          isOpen={this.state.isReportingActionsPopoverOpen}
+          closePopover={() => this.setState({ isReportingActionsPopoverOpen: false })}
+        >
+          <EuiContextMenu initialPanelId={0} panels={reportingActionPanels} />
+        </EuiPopover>
+      </div>
+    ) : null;
+
     return (
       <div style={pageStyles}>
         <EuiPage>
           <EuiPageBody component="div">
             <EuiPageHeader>
-              <EuiPageHeaderSection>
+              <EuiPageHeaderSection id="notebookTitle">
                 <EuiTitle size="l">
                   <h1>{this.state.path}</h1>
                 </EuiTitle>
@@ -790,6 +896,9 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                       closePopover={() => this.setState({ isParaActionsPopoverOpen: false })}>
                       <EuiContextMenu initialPanelId={0} panels={paraActionsPanels} />
                     </EuiPopover>
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    {showReportingContextMenu}
                   </EuiFlexItem>
                   <EuiFlexItem>
                     <EuiPopover

--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -606,7 +606,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     {
       headers: {
         'Content-Type': 'application/json',
-        'osd-version': '7.10.2',
+        'osd-version': '1.0.0',
         'accept-language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,zh-TW;q=0.6',
         pragma: 'no-cache',
         'sec-fetch-dest': 'empty',


### PR DESCRIPTION
### Description
Add context menu for Reporting if the reporting plugin is also installed, with same functionality as Reporting context menu.

`To-do`: Add logic in OpenSearch dashboards-reports to re-route correctly to `Create report definition`
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
