### PR TITLE
Fix run all paragraphs for visualizations

### DIFF
--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -455,7 +455,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         body: JSON.stringify(paraUpdateObject),
       })
       .then(async (res) => {
-        if (res.output[0].outputType === 'QUERY') {
+        if (res.output[0]?.outputType === 'QUERY') {
           await this.loadQueryResultsFromInput(res);
           const checkErrorJSON = JSON.parse(res.output[0].result);
           if (this.checkQueryOutputError(checkErrorJSON)) {

--- a/dashboards-notebooks/server/adaptors/default_backend.ts
+++ b/dashboards-notebooks/server/adaptors/default_backend.ts
@@ -326,7 +326,7 @@ export class DefaultBackend implements NotebookAdaptor {
       for (index = 0; index < paragraphs.length; ++index) {
         const startTime = now();
         const updatedParagraph = { ...paragraphs[index] };
-        if (paragraphs[index].input.inputType === 'MARKDOWN' && paragraphs[index].id === paragraphId) {
+        if (paragraphs[index].id === paragraphId) {
           updatedParagraph.dateModified = new Date().toISOString();
           if (inputIsQuery(paragraphs[index].input.inputText)) {
             updatedParagraph.output = [
@@ -344,7 +344,7 @@ export class DefaultBackend implements NotebookAdaptor {
                 execution_time: `${(now() - startTime).toFixed(3)} ms`,
               },
             ];
-          } else if (paragraphs[index].input.inputType === 'VISUALIZATION' && paragraphs[index].id === paragraphId) {
+          } else if (paragraphs[index].input.inputType === 'VISUALIZATION') {
             updatedParagraph.dateModified = new Date().toISOString();
             updatedParagraph.output = [
               {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Fix bug preventing running visualizations again after output is cleared
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
