### PR TITLE
Add more delay for cypress when running sql

### DIFF
--- a/dashboards-notebooks/.cypress/integration/ui.spec.js
+++ b/dashboards-notebooks/.cypress/integration/ui.spec.js
@@ -239,7 +239,7 @@ describe('Testing paragraphs', () => {
     cy.get('.euiTextArea').type(SQL_QUERY_TEXT);
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Run').click();
-    cy.wait(delay);
+    cy.wait(delay * 5);
 
     cy.get('.sc-Axmtr > div:nth-child(1) > div:nth-child(1)').contains('select * from opensearch_dashboards_sample_data_flights limit 20');
 
@@ -255,7 +255,7 @@ describe('Testing paragraphs', () => {
     cy.get('.euiTextArea').type(PPL_QUERY_TEXT);
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Run').click();
-    cy.wait(delay);
+    cy.wait(delay * 5);
 
     cy.get('.sc-Axmtr > div:nth-child(1) > div:nth-child(1)').contains('source=opensearch_dashboards_sample_data_flights');
 


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Some other elements also match `.sc-Axmtr > div:nth-child(1) > div:nth-child(1)` and are captured by cypress before sql table loads, so cypress is unable to find the query string `select * from opensearch_dashboards_sample_data_flights limit 20` in those matched elements. Adding more delay for sql table to load first.

Todo for improvement: add test id attributes on sql table and make the selectors more specific
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
