### PR TITLE
Remove checking toasts in cypress

### DIFF
--- a/dashboards-notebooks/.cypress/integration/ui.spec.js
+++ b/dashboards-notebooks/.cypress/integration/ui.spec.js
@@ -317,8 +317,6 @@ describe('Testing paragraphs', () => {
     cy.get('.euiButton__text').contains('Duplicate').click();
     cy.wait(delay * 3);
 
-    cy.get('.euiToastHeader__title').contains('success').should('exist');
-
     cy.get('.euiButton__text').contains('Notebook actions').click();
     cy.wait(delay);
     cy.get('.euiContextMenuItem__text').contains('Rename notebook').click();


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Checking results by reading toasts seems to lead to unstable tests, removing it. The functionality is still being verified by line 331. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
