### PR TITLE
Fix error message when paragraph exceeds max_payload

### DIFF
--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -483,7 +483,10 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
         this.setState({ paragraphs, parsedPara });
       })
       .catch((err) => {
-        this.props.setToast('Error running paragraph, please make sure you have the correct permission.', 'danger');
+        if (err.body.statusCode === 413)
+          this.props.setToast(`Error running paragraph: ${err.body.message}`, 'danger');
+        else
+          this.props.setToast('Error running paragraph, please make sure you have the correct permission.', 'danger');
         console.error(err.body.message);
       });
   };


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Update error message when paragraph is larger than `server.maxPayloadBytes`
 
### Issues Resolved
- #32 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
