### PR TITLE
Memoize QueryDataGrid to Reduce Re-renders

### DIFF
--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -882,101 +882,6 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     const showLoadingModal = (this.state.isReportingLoadingModalOpen) ?
     <GenerateReportLoadingModal setShowLoading={this.toggleReportingLoadingModal} /> : null;
 
-    const paragraphDisplay = (this.state.parsedPara.length > 0) ? (
-      <>
-      <Cells>
-        {/* <PanelWrapper> */}
-          {this.state.parsedPara.map((para: ParaType, index: number) => (
-            <div ref={this.state.parsedPara[index].paraDivRef} key={`para_div_${para.uniqueId}`} style={panelStyles}>
-              <Paragraphs
-                ref={this.state.parsedPara[index].paraRef}
-                para={para}
-                setPara={(para: ParaType) => this.setPara(para, index)}
-                dateModified={this.state.paragraphs[index]?.dateModified}
-                index={index}
-                paraCount={this.state.parsedPara.length}
-                paragraphSelector={this.paragraphSelector}
-                textValueEditor={(textValue: React.ChangeEvent<HTMLTextAreaElement>, index: number) => this.textValueEditor(textValue, index)}
-                handleKeyPress={this.handleKeyPress}
-                addPara={this.addPara}
-                DashboardContainerByValueRenderer={this.props.DashboardContainerByValueRenderer}
-                deleteVizualization={this.deleteVizualization}
-                http={this.props.http}
-                selectedViewId={this.state.selectedViewId}
-                setSelectedViewId={this.updateView}
-                deletePara={this.showDeleteParaModal}
-                runPara={this.updateRunParagraph}
-                clonePara={this.cloneParaButton}
-                movePara={this.movePara}
-                showQueryParagraphError={this.state.showQueryParagraphError}
-                queryParagraphErrorMessage={this.state.queryParagraphErrorMessage}
-              />
-            </div>
-          ))}
-        {/* </PanelWrapper> */}
-      </Cells>
-      {this.state.selectedViewId !== 'output_only' &&
-        <EuiPopover
-          panelPaddingSize="none"
-          withTitle
-          button={
-            <EuiButton
-              iconType='arrowDown'
-              iconSide='right'
-              onClick={() => this.setState({ isAddParaPopoverOpen: true })}
-            >Add paragraph</EuiButton>
-          }
-          isOpen={this.state.isAddParaPopoverOpen}
-          closePopover={() => this.setState({ isAddParaPopoverOpen: false })}>
-          <EuiContextMenu initialPanelId={0} panels={addParaPanels} />
-        </EuiPopover>
-      }
-    </>
-    ) : (
-      // show default paragraph if no paragraphs in this notebook
-      <div style={panelStyles}>
-        <EuiPanel>
-          <EuiSpacer size='xxl' />
-          <EuiText textAlign='center'>
-            <h2>No paragraphs</h2>
-            <EuiText>
-              Add a paragraph to compose your document or story. Notebooks now support two types of input:
-            </EuiText>
-          </EuiText>
-          <EuiSpacer size='xl' />
-          <EuiFlexGroup justifyContent='spaceEvenly'>
-            <EuiFlexItem grow={2} />
-            <EuiFlexItem grow={3}>
-              <EuiCard
-                icon={<EuiIcon size="xxl" type="editorCodeBlock" />}
-                title="Code block"
-                description="Write contents directly using markdown, SQL or PPL."
-                footer={
-                  <EuiButton onClick={() => this.addPara(0, '', 'CODE')} style={{ marginBottom: 17 }}>
-                    Add code block
-                  </EuiButton>
-                }
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={3}>
-              <EuiCard
-                icon={<EuiIcon size="xxl" type="visArea" />}
-                title="OpenSearch Dashboards visualization"
-                description="Import OpenSearch Dashboards visualizations to the notes."
-                footer={
-                  <EuiButton onClick={() => this.addPara(0, '', 'VISUALIZATION')} style={{ marginBottom: 17 }}>
-                    Add visualization
-                  </EuiButton>
-                }
-              />
-            </EuiFlexItem>
-            <EuiFlexItem grow={2} />
-          </EuiFlexGroup>
-          <EuiSpacer size='xxl' />
-        </EuiPanel>
-      </div>
-    );
-
     return (
       <div style={pageStyles}>
         <EuiPage>
@@ -1061,7 +966,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                           index={index}
                           paraCount={this.state.parsedPara.length}
                           paragraphSelector={this.paragraphSelector}
-                          textValueEditor={(textValue: React.ChangeEvent<HTMLTextAreaElement>, index: number) => this.textValueEditor(textValue, index)}
+                          textValueEditor={this.textValueEditor}
                           handleKeyPress={this.handleKeyPress}
                           addPara={this.addPara}
                           DashboardContainerByValueRenderer={this.props.DashboardContainerByValueRenderer}

--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -882,6 +882,101 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
     const showLoadingModal = (this.state.isReportingLoadingModalOpen) ?
     <GenerateReportLoadingModal setShowLoading={this.toggleReportingLoadingModal} /> : null;
 
+    const paragraphDisplay = (this.state.parsedPara.length > 0) ? (
+      <>
+      <Cells>
+        {/* <PanelWrapper> */}
+          {this.state.parsedPara.map((para: ParaType, index: number) => (
+            <div ref={this.state.parsedPara[index].paraDivRef} key={`para_div_${para.uniqueId}`} style={panelStyles}>
+              <Paragraphs
+                ref={this.state.parsedPara[index].paraRef}
+                para={para}
+                setPara={(para: ParaType) => this.setPara(para, index)}
+                dateModified={this.state.paragraphs[index]?.dateModified}
+                index={index}
+                paraCount={this.state.parsedPara.length}
+                paragraphSelector={this.paragraphSelector}
+                textValueEditor={(textValue: React.ChangeEvent<HTMLTextAreaElement>, index: number) => this.textValueEditor(textValue, index)}
+                handleKeyPress={this.handleKeyPress}
+                addPara={this.addPara}
+                DashboardContainerByValueRenderer={this.props.DashboardContainerByValueRenderer}
+                deleteVizualization={this.deleteVizualization}
+                http={this.props.http}
+                selectedViewId={this.state.selectedViewId}
+                setSelectedViewId={this.updateView}
+                deletePara={this.showDeleteParaModal}
+                runPara={this.updateRunParagraph}
+                clonePara={this.cloneParaButton}
+                movePara={this.movePara}
+                showQueryParagraphError={this.state.showQueryParagraphError}
+                queryParagraphErrorMessage={this.state.queryParagraphErrorMessage}
+              />
+            </div>
+          ))}
+        {/* </PanelWrapper> */}
+      </Cells>
+      {this.state.selectedViewId !== 'output_only' &&
+        <EuiPopover
+          panelPaddingSize="none"
+          withTitle
+          button={
+            <EuiButton
+              iconType='arrowDown'
+              iconSide='right'
+              onClick={() => this.setState({ isAddParaPopoverOpen: true })}
+            >Add paragraph</EuiButton>
+          }
+          isOpen={this.state.isAddParaPopoverOpen}
+          closePopover={() => this.setState({ isAddParaPopoverOpen: false })}>
+          <EuiContextMenu initialPanelId={0} panels={addParaPanels} />
+        </EuiPopover>
+      }
+    </>
+    ) : (
+      // show default paragraph if no paragraphs in this notebook
+      <div style={panelStyles}>
+        <EuiPanel>
+          <EuiSpacer size='xxl' />
+          <EuiText textAlign='center'>
+            <h2>No paragraphs</h2>
+            <EuiText>
+              Add a paragraph to compose your document or story. Notebooks now support two types of input:
+            </EuiText>
+          </EuiText>
+          <EuiSpacer size='xl' />
+          <EuiFlexGroup justifyContent='spaceEvenly'>
+            <EuiFlexItem grow={2} />
+            <EuiFlexItem grow={3}>
+              <EuiCard
+                icon={<EuiIcon size="xxl" type="editorCodeBlock" />}
+                title="Code block"
+                description="Write contents directly using markdown, SQL or PPL."
+                footer={
+                  <EuiButton onClick={() => this.addPara(0, '', 'CODE')} style={{ marginBottom: 17 }}>
+                    Add code block
+                  </EuiButton>
+                }
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={3}>
+              <EuiCard
+                icon={<EuiIcon size="xxl" type="visArea" />}
+                title="OpenSearch Dashboards visualization"
+                description="Import OpenSearch Dashboards visualizations to the notes."
+                footer={
+                  <EuiButton onClick={() => this.addPara(0, '', 'VISUALIZATION')} style={{ marginBottom: 17 }}>
+                    Add visualization
+                  </EuiButton>
+                }
+              />
+            </EuiFlexItem>
+            <EuiFlexItem grow={2} />
+          </EuiFlexGroup>
+          <EuiSpacer size='xxl' />
+        </EuiPanel>
+      </div>
+    );
+
     return (
       <div style={pageStyles}>
         <EuiPage>
@@ -966,7 +1061,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
                           index={index}
                           paraCount={this.state.parsedPara.length}
                           paragraphSelector={this.paragraphSelector}
-                          textValueEditor={this.textValueEditor}
+                          textValueEditor={(textValue: React.ChangeEvent<HTMLTextAreaElement>, index: number) => this.textValueEditor(textValue, index)}
                           handleKeyPress={this.handleKeyPress}
                           addPara={this.addPara}
                           DashboardContainerByValueRenderer={this.props.DashboardContainerByValueRenderer}

--- a/dashboards-notebooks/public/components/paragraph_components/para_output.tsx
+++ b/dashboards-notebooks/public/components/paragraph_components/para_output.tsx
@@ -32,7 +32,7 @@ import { EuiText, EuiSpacer, EuiCodeBlock } from '@elastic/eui';
 
 import { DATE_FORMAT, ParaType } from '../../../common';
 import { DashboardContainerInput, DashboardStart } from '../../../../../src/plugins/dashboard/public';
-import { QueryDataGrid } from './para_query_grid';
+import { QueryDataGridMemo } from './para_query_grid';
 import moment from 'moment';
 
 /*
@@ -92,6 +92,7 @@ export const ParaOutput = (props: {
      * Currently supports HTML, TABLE, IMG
      * TODO: add table rendering
      */
+
     if (typeOut !== undefined) {
       switch (typeOut) {
         case 'QUERY':
@@ -114,7 +115,7 @@ export const ParaOutput = (props: {
               <div>
                 <EuiText key={'query-input-key'}><b>{inputQuery}</b></EuiText>
                 <EuiSpacer/>
-                <QueryDataGrid
+                <QueryDataGridMemo
                   key={key}
                   rowCount={queryObject.datarows.length}
                   queryColumns={columns}

--- a/dashboards-notebooks/public/components/paragraph_components/para_query_grid.tsx
+++ b/dashboards-notebooks/public/components/paragraph_components/para_query_grid.tsx
@@ -137,3 +137,12 @@ export function QueryDataGrid(props: QueryDataGridProps) {
     </div>
   )
 }
+
+function queryDataGridPropsAreEqual(prevProps: QueryDataGridProps, nextProps: QueryDataGridProps) {
+  return prevProps.rowCount === nextProps.rowCount
+    && JSON.stringify(prevProps.queryColumns) === JSON.stringify(nextProps.queryColumns)
+    && JSON.stringify(prevProps.visibleColumns) === JSON.stringify(nextProps.visibleColumns)
+    && JSON.stringify(prevProps.dataValues) === JSON.stringify(nextProps.dataValues)
+}
+
+export const QueryDataGridMemo = React.memo(QueryDataGrid, queryDataGridPropsAreEqual);

--- a/dashboards-notebooks/public/components/paragraph_components/para_query_grid.tsx
+++ b/dashboards-notebooks/public/components/paragraph_components/para_query_grid.tsx
@@ -44,7 +44,7 @@ type RenderCellValueProps = {
   columnId: string
 }
 
-export function QueryDataGrid(props: QueryDataGridProps) {
+function QueryDataGrid(props: QueryDataGridProps) {
   const {
     rowCount,
     queryColumns,


### PR DESCRIPTION
### Description
Memoize the `QueryDataGrid` component to avoid unnecessary re-renders and improve performance. Also fixes bug where columns would snap back into place after having width edited.
 
### Issues Resolved
#23 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
