### PR TITLE
Add cypress test suite for reporting context menu

### DIFF
--- a/dashboards-notebooks/.cypress/integration/ui.spec.js
+++ b/dashboards-notebooks/.cypress/integration/ui.spec.js
@@ -35,6 +35,8 @@ import {
   PPL_QUERY_TEXT
 } from "../utils/constants";
 
+import { skipOn } from '@cypress/skip-test'
+
 describe('Adding sample data and visualization', () => {
   it('Adds sample flights data for visualization paragraph', () => {
     cy.visit(`${Cypress.env('opensearchDashboards')}/app/home#/tutorial_directory/sampleData`);
@@ -127,6 +129,58 @@ describe('Testing notebooks table', () => {
     cy.get('input.euiFieldText').type(TEST_NOTEBOOK);
     cy.get('.euiButton__text').contains(/^Create$/).click();
     cy.wait(delay * 2);
+  });
+});
+
+describe('Test reporting integration if plugin installed', () => {
+  beforeEach(() => {
+    cy.visit(`${Cypress.env('opensearchDashboards')}/app/notebooks-dashboards#`);
+    cy.get('.euiTableCellContent').contains(TEST_NOTEBOOK).click();
+    cy.wait(delay * 3);
+    cy.get('body').then($body => {
+      skipOn($body.find('#reportingActionsButton').length <= 0);
+    });
+  });
+
+  it('Create in-context PDF report from notebook', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.wait(delay);
+    cy.get('button.euiContextMenuItem:nth-child(1)').contains('Download PDF').click();
+    cy.get('#downloadInProgressLoadingModal').should('exist');
+    cy.get('div.euiFlexGroup:nth-child(6) > div:nth-child(1) > button:nth-child(1)').click();
+  });
+
+  it('Create in-context PNG report from notebook', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.wait(delay);
+    cy.get('button.euiContextMenuItem:nth-child(2)').contains('Download PNG').click();
+    cy.get('#downloadInProgressLoadingModal').should('exist');
+    cy.get('div.euiFlexGroup:nth-child(6) > div:nth-child(1) > button:nth-child(1)').click();
+  });
+
+  it('Create on-demand report definition from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.wait(delay);
+    cy.get('button.euiContextMenuItem:nth-child(3)').contains('Create report definition').click();
+    cy.wait(delay);
+    cy.location('pathname', { timeout: 60000 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+    cy.wait(delay);
+    cy.get('#reportSettingsName').type('Create notebook on-demand report');
+    cy.get('#createNewReportDefinition').click({ force: true });
+  });
+
+  it ('View reports homepage from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.wait(delay);
+    cy.get('button.euiContextMenuItem:nth-child(4)').contains('View reports').click();
+    cy.wait(delay);
+    cy.location('pathname', { timeout: 60000 }).should(
+      'include',
+      '/reports-dashboards'
+    );
   });
 });
 

--- a/dashboards-notebooks/.cypress/integration/ui.spec.js
+++ b/dashboards-notebooks/.cypress/integration/ui.spec.js
@@ -147,7 +147,6 @@ describe('Test reporting integration if plugin installed', () => {
     cy.wait(delay);
     cy.get('button.euiContextMenuItem:nth-child(1)').contains('Download PDF').click();
     cy.get('#downloadInProgressLoadingModal').should('exist');
-    cy.get('div.euiFlexGroup:nth-child(6) > div:nth-child(1) > button:nth-child(1)').click();
   });
 
   it('Create in-context PNG report from notebook', () => {
@@ -155,7 +154,6 @@ describe('Test reporting integration if plugin installed', () => {
     cy.wait(delay);
     cy.get('button.euiContextMenuItem:nth-child(2)').contains('Download PNG').click();
     cy.get('#downloadInProgressLoadingModal').should('exist');
-    cy.get('div.euiFlexGroup:nth-child(6) > div:nth-child(1) > button:nth-child(1)').click();
   });
 
   it('Create on-demand report definition from context menu', () => {

--- a/dashboards-notebooks/package.json
+++ b/dashboards-notebooks/package.json
@@ -26,6 +26,7 @@
     "performance-now": "^2.1.0"
   },
   "dependencies": {
+    "@cypress/skip-test": "^2.6.1",
     "@nteract/outputs": "^3.0.11",
     "@nteract/presentational-components": "^3.4.3"
   },

--- a/dashboards-notebooks/public/components/notebook.tsx
+++ b/dashboards-notebooks/public/components/notebook.tsx
@@ -864,6 +864,7 @@ export class Notebook extends Component<NotebookProps, NotebookState> {
           withTitle
           button={
             <EuiButton
+              id='reportingActionsButton'
               iconType='arrowDown'
               iconSide='right'
               onClick={() => this.setState({ isReportingActionsPopoverOpen: true })}

--- a/dashboards-notebooks/yarn.lock
+++ b/dashboards-notebooks/yarn.lock
@@ -100,6 +100,11 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+"@cypress/skip-test@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@cypress/skip-test/-/skip-test-2.6.1.tgz#44a4bc4c2b2e369a7661177c9b38e50d417a36ea"
+  integrity sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==
+
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"


### PR DESCRIPTION
Signed-off-by: David Cui <davidcui@amazon.com>

### Description
Add cypress test suite for reporting context menu functionality to ensure integration is working. Skips the test suite if reporting plugin is not installed
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
