### PR TITLE
Bump opensearch ref to 1.1 in CI

### DIFF
--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
-  OPENSEARCH_BRANCH: '1.x'
+  OPENSEARCH_BRANCH: '1.1'
   COMMON_UTILS_BRANCH: 'main'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Complete OpenSearch Dashboards Notebooks is composed of 2 plugins.
 
 ## Contributing
 
-See [developer guide](DEVELOPER_GUIDE.md) and [how to contribute to this project](CONTRIBUTING.md). 
+See [developer guide](./dashboards-notebooks/DEVELOPER_GUIDE.md) and [how to contribute to this project](CONTRIBUTING.md). 
 
 ## Getting Help
 
@@ -30,8 +30,8 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## License
 
-This project is licensed under the [Apache v2.0 License](LICENSE.txt).
+This project is licensed under the [Apache v2.0 License](LICENSE).
 
 ## Copyright
 
-Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE) for details.

--- a/dashboards-notebooks/DEVELOPER_GUIDE.md
+++ b/dashboards-notebooks/DEVELOPER_GUIDE.md
@@ -48,4 +48,4 @@ Example output: `./build/notebooks-dashboards*.zip`
 
 ### Submitting Changes
 
-See [CONTRIBUTING](CONTRIBUTING.md).
+See [CONTRIBUTING](../CONTRIBUTING.md).

--- a/dashboards-notebooks/README.md
+++ b/dashboards-notebooks/README.md
@@ -26,7 +26,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## License
 
-This project is licensed under the [Apache v2.0 License](../LICENSE.txt).
+This project is licensed under the [Apache v2.0 License](../LICENSE).
 
 ## Copyright
 

--- a/release-notes/opensearch-dashboards-notebooks.release-notes-1.1.0.0.md
+++ b/release-notes/opensearch-dashboards-notebooks.release-notes-1.1.0.0.md
@@ -7,6 +7,7 @@ Compatible with OpenSearch 1.1.0
 
 ### Infrastructure
 * Fix snapshot build and depend on OpenSearch 1.1. ([#62](https://github.com/opensearch-project/dashboards-notebooks/pull/62))
+* Bump opensearch ref to 1.1 in CI ([#73](https://github.com/opensearch-project/dashboards-reports/pull/73))
 
 ### Documentation
 * Update release notes for 1.1.0 release ([#71](https://github.com/opensearch-project/dashboards-notebooks/pull/71))


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Core has `1.1` branch cut and bumped `1.x` minor version to `1.2`, use opensearch ref to 1.1 in CI

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
