### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/.github/workflows/dashboards-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-notebooks-test-and-build-workflow.yml
@@ -6,7 +6,7 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: notebooks-dashboards
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_PLUGIN_VERSION: 1.1.0.0
+  OPENSEARCH_PLUGIN_VERSION: 1.2.0.0
 
 jobs:
 

--- a/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
+++ b/.github/workflows/opensearch-notebooks-test-and-build-workflow.yml
@@ -3,8 +3,8 @@ name: Test and Build OpenSearch Notebooks Backend Plugin
 on: [push, pull_request]
 
 env:
-  OPENSEARCH_VERSION: '1.1.0-SNAPSHOT'
-  OPENSEARCH_BRANCH: '1.1'
+  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
+  OPENSEARCH_BRANCH: '1.x'
   COMMON_UTILS_BRANCH: 'main'
 
 jobs:

--- a/dashboards-notebooks/opensearch_dashboards.json
+++ b/dashboards-notebooks/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "notebooksDashboards",
-  "version": "1.1.0.0",
-  "opensearchDashboardsVersion": "1.1.0",
+  "version": "1.2.0.0",
+  "opensearchDashboardsVersion": "1.2.0",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation", "embeddable", "dashboard"],

--- a/dashboards-notebooks/package.json
+++ b/dashboards-notebooks/package.json
@@ -1,11 +1,11 @@
 {
   "name": "notebooks-dashboards",
-  "version": "1.1.0.0",
+  "version": "1.2.0.0",
   "description": "OpenSearch Dashboards Notebooks",
   "main": "index.ts",
   "license": "Apache-2.0",
   "opensearchDashboards": {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "templateVersion": "1.0.0"
   },
   "scripts": {

--- a/opensearch-notebooks/build.gradle
+++ b/opensearch-notebooks/build.gradle
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.0-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
@@ -154,7 +154,7 @@ dependencies {
     testCompile "org.opensearch.test:framework:${opensearch_version}"
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testCompile "org.mockito:mockito-core:2.23.0"
+    testCompile "org.mockito:mockito-core:3.12.4"
     testCompile "com.google.code.gson:gson:2.8.6"
 
     ktlint "com.pinterest:ktlint:0.33.0"


### PR DESCRIPTION
### Description
Bump version to 1.2.0 for OpenSearch and OpenSearch Dashboards.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/dashboards-notebooks/issues/81
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
